### PR TITLE
Feature/docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+client/node_modules
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ settings.json
 
 .env
 */logfiles
+.idea

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "graph_pruner",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://server:8000",
+  "proxy": "http://localhost:8000",
   "dependencies": {
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "graph_pruner",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://localhost:8000",
+  "proxy": "http://server:8000",
   "dependencies": {
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
@@ -38,6 +38,9 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.16.7"
   },
   "eslintConfig": {
     "extends": [

--- a/client/src/shared/api.js
+++ b/client/src/shared/api.js
@@ -1,5 +1,12 @@
 import axios from "axios";
 
+// to get frontend and backend can be deployed in different ways
+// we need to set the base url for axios
+
+// if there is a server host env variable, use that
+// otherwise, use localhost
+axios.defaults.baseURL = process.env.REACT_APP_SERVER_HOST || "http://localhost:8000";
+
 export const updateItem = (itemId, itemType, data) => {
   return axios.patch(`/graph/${itemId}?item_type=${itemType}`, data);
 };

--- a/client/src/shared/api.js
+++ b/client/src/shared/api.js
@@ -23,19 +23,19 @@ export const updateSettings = (graphId, data) => {
 };
 
 export const getPlugins = () => {
-  return axios.get("/plugin");
+  return axios.get("/plugin/");
 };
 
 export const createGraph = (data) => {
-  return axios.post("/graph", data);
+  return axios.post("/graph/", data);
 };
 
 export const getGraphs = () => {
-  return axios.get("/graph");
+  return axios.get("/graph/");
 };
 
 export const deleteGraph = (graphId) => {
-  return axios.delete(`/graph/${graphId}`);
+  return axios.delete(`/graph/${graphId}/`);
 };
 
 export const acknowledge = (

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -37,6 +37,20 @@ First, clone the CleanGraph repository to your local machine:
 git clone https://github.com/nlp-tlp/CleanGraph
 ```
 
+
+## Alternative step 2: use docker and docker-compose to spin up the project
+
+First, you will need to have `docker` and `docker-compose`
+Then you can run the following command to spin up the project
+
+```bash
+docker-compose -f scripts/compose/docker-compose.yml up
+```
+It will take a while for the first time to spin up the project, but after that, it will be much faster.
+The reason is that the docker image will be cached locally, also the `npm install` will take a while to install all the dependencies.
+
+If you get this step done successfully, you can skip the rest of the steps to spin up the project.
+
 ## Step 2: Setup the Client
 
 Navigate into the `client/` directory. Install the client dependencies by running:

--- a/scripts/compose/docker-compose.yml
+++ b/scripts/compose/docker-compose.yml
@@ -43,7 +43,12 @@ services:
     build:
       context: ../../
       dockerfile: ./scripts/dockerfile/dockerfile_client
-    command: npm run start
+    command:
+      - /bin/sh
+      - -c
+      - |
+        npm install --no-package-lock
+        npm run start
     container_name: clean_graph_client
     platform: linux/x86_64
     volumes:
@@ -62,4 +67,3 @@ volumes:
 
 networks:
   cleangraph:
-    external: true

--- a/scripts/compose/docker-compose.yml
+++ b/scripts/compose/docker-compose.yml
@@ -18,8 +18,6 @@ services:
       - "8000:8000"
     volumes:
       - ../../server:/app
-    links:
-      - mongodb
     networks:
       cleangraph:
         aliases:
@@ -51,12 +49,12 @@ services:
         npm run start
     container_name: clean_graph_client
     platform: linux/x86_64
+    environment:
+      REACT_APP_SERVER_URL: http://server.local:8000
     volumes:
       - ../../client:/app
     ports:
       - "3000:3000"
-    links:
-      - server
     networks:
       cleangraph:
         aliases:

--- a/scripts/compose/docker-compose.yml
+++ b/scripts/compose/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ../../
       dockerfile: ./scripts/dockerfile/dockerfile_server
-    command: uvicorn --host 0.0.0.0 main:app
+    command: uvicorn --host 0.0.0.0 --reload main:app
     container_name: clean_graph_server
     platform: linux/x86_64
     environment:

--- a/scripts/compose/docker-compose.yml
+++ b/scripts/compose/docker-compose.yml
@@ -1,0 +1,65 @@
+version: "3"
+
+services:
+  server:
+    build:
+      context: ../../
+      dockerfile: ./scripts/dockerfile/dockerfile_server
+    command: uvicorn --host 0.0.0.0 main:app
+    container_name: clean_graph_server
+    platform: linux/x86_64
+    environment:
+      MONGO_DB_USERNAME: root
+      MONGO_DB_PASSWORD: examplepassword
+      MONGO_CLUSTER_NAME: ""
+      MONGO_DB_NAME: "cleangraph"
+      MONGO_URI: mongodb://root:examplepassword@mongo.local:27017
+    ports:
+      - "8000:8000"
+    volumes:
+      - ../../server:/app
+    links:
+      - mongodb
+    networks:
+      cleangraph:
+        aliases:
+          - server.local
+
+  mongodb:
+    image: mongo:latest
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: examplepassword
+    networks:
+      cleangraph:
+        aliases:
+          - mongo.local
+
+  client:
+    build:
+      context: ../../
+      dockerfile: ./scripts/dockerfile/dockerfile_client
+    command: npm run start
+    container_name: clean_graph_client
+    platform: linux/x86_64
+    volumes:
+      - ../../client:/app
+    ports:
+      - "3000:3000"
+    links:
+      - server
+    networks:
+      cleangraph:
+        aliases:
+          - client.local
+
+volumes:
+  mongodb_data:
+
+networks:
+  cleangraph:
+    external: true

--- a/scripts/dockerfile/dockerfile_client
+++ b/scripts/dockerfile/dockerfile_client
@@ -9,6 +9,3 @@ COPY /client/package.json ./
 
 # Copy the content of the local src directory to the working directory
 COPY ./client .
-
-# Specify the command to run on container start
-CMD ["npm", "start"]

--- a/scripts/dockerfile/dockerfile_client
+++ b/scripts/dockerfile/dockerfile_client
@@ -1,0 +1,14 @@
+# Use an official Node runtime as the parent image
+FROM node:14
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json to the container
+COPY /client/package.json ./
+
+# Copy the content of the local src directory to the working directory
+COPY ./client .
+
+# Specify the command to run on container start
+CMD ["npm", "start"]

--- a/scripts/dockerfile/dockerfile_server
+++ b/scripts/dockerfile/dockerfile_server
@@ -1,0 +1,17 @@
+# Start with a base image containing Python 3.8
+FROM python:3.10-slim
+RUN apt-get update && apt-get install -y --no-install-recommends gcc build-essential python3-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libgdal-dev
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+ADD ./server /app
+
+# Install any needed packages specified in requirements.txt
+RUN pip install -r requirements.txt
+
+# RUN uvicorn main:app

--- a/server/main.py
+++ b/server/main.py
@@ -50,7 +50,7 @@ def set_logger():
 set_logger()
 
 
-origins = ["*"]
+origins = ["http://localhost:3000", "localhost:3000"]
 
 app = FastAPI(title="CleanGraph API", version="1.0.0", dependencies=[])
 
@@ -58,7 +58,7 @@ app.add_middleware(LoguruMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/server/main.py
+++ b/server/main.py
@@ -20,7 +20,7 @@ def set_logger():
     logger.add(
         sys.stdout,
         colorize=True,
-        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level}</level> | <level>{message}</level>",
+        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level}</level> | <cyan>{file}:{line}</cyan> | <level>{message}</level>",
         level="INFO",
         enqueue=True,
     )
@@ -50,7 +50,7 @@ def set_logger():
 set_logger()
 
 
-origins = ["http://localhost:3000", "localhost:3000"]
+origins = ["*"]
 
 app = FastAPI(title="CleanGraph API", version="1.0.0", dependencies=[])
 
@@ -58,7 +58,7 @@ app.add_middleware(LoguruMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
Get the backend/frontend/database running inside a `docker-compose` file

In general, several changes have been made to make this happen

- client/server and MongoDB all inside their own container. 
- add some `/` to the end of the route, to make sure the frontend call to the backend does not get 307 redirect problem due to the `/graph` => `/graph/`
- add the `baseUrl` for the `Axios` as it can not proxy to `localhost:8000` inside the container (the backend is in another container). At the same time, this way can allow frontend and backend deployment to different places. 
- add a simple documentation
- add line and file no for the logs, so can locate the problem more easier